### PR TITLE
Artur

### DIFF
--- a/cluster.example.yaml
+++ b/cluster.example.yaml
@@ -3,7 +3,7 @@ public_ssh_key_path: ~/.ssh/id_ed25519.pub
 private_ssh_key_path: ~/.ssh/id_ed25519
 provider_id: aws
 region: us-east-1
-availability_zone: us-east-1a
+availability_zone: us-east-1c
 use_node_affinity: false
 use_elastic_fabric_adapters: false
 use_elastic_file_system: true

--- a/cluster.example.yaml
+++ b/cluster.example.yaml
@@ -3,7 +3,7 @@ public_ssh_key_path: ~/.ssh/id_ed25519.pub
 private_ssh_key_path: ~/.ssh/id_ed25519
 provider_id: aws
 region: us-east-1
-availability_zone: us-east-1c
+availability_zone: us-east-1a
 use_node_affinity: false
 use_elastic_fabric_adapters: false
 use_elastic_file_system: true
@@ -14,15 +14,14 @@ nodes:
     image_id: ami-0845a3d4093ba6e49
 
   - instance_type: t3.2xlarge
-    allocation_mode: on-demand
+    allocation_mode: spot
     burstable_mode: Unlimited
     image_id: ami-0845a3d4093ba6e49
     init_commands:
       - ls
-      - ls -a
 
   - instance_type: m5.2xlarge
-    allocation_mode: on-demand
+    allocation_mode: spot
     image_id: ami-0845a3d4093ba6e49
     init_commands:
       - ls

--- a/src/commands/cluster/create.rs
+++ b/src/commands/cluster/create.rs
@@ -15,6 +15,7 @@ use tracing::{error, info};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ClusterYaml {
+    id: Option<String>,
     display_name: String,
     provider_id: Option<String>,
     provider_config_id: Option<i64>,
@@ -209,7 +210,10 @@ pub async fn create(
     }
 
     // Validate node data
-    let new_cluster_id = utils::generate_id();
+    let new_cluster_id = match cluster_yaml.id {
+        Some(id) => id,
+        None => utils::generate_id(),
+    };
     let mut nodes_to_insert: Vec<Node> = vec![];
     let mut commands_to_insert: Vec<ShellCommand> = vec![];
     let node_count = cluster_yaml.nodes.len() as u64;
@@ -295,7 +299,11 @@ pub async fn create(
                         bail!(
                             "Invalid burstable mode '{}' specified for node '{}'.\
                             The instance type '{}' in region '{}' only supports the following burstale modes: {}",
-                            burstable_mode, i+1, &instance_type_name, &region, valid_modes.join(", ")
+                            burstable_mode,
+                            i + 1,
+                            &instance_type_name,
+                            &region,
+                            valid_modes.join(", ")
                         )
                     }
                     Some(burstable_mode)

--- a/src/database/models/cluster.rs
+++ b/src/database/models/cluster.rs
@@ -55,7 +55,7 @@ impl std::str::FromStr for ClusterState {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Cluster {
     pub id: String,
     pub display_name: String,

--- a/src/database/models/node.rs
+++ b/src/database/models/node.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Transaction, sqlite::SqlitePool};
 use tracing::error;
 
-#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Node {
     pub id: String,
     pub cluster_id: String,

--- a/src/integrations/providers/aws/resources/elastic_compute.rs
+++ b/src/integrations/providers/aws/resources/elastic_compute.rs
@@ -14,6 +14,9 @@ impl AwsInterface {
     ) -> Result<String> {
         let instance_name = context.ec2_instance_name(node_index);
 
+        // Sleep for 20s to give time for the IAM Profile to be propagated
+        sleep(Duration::from_secs(20)).await;
+
         let describe_instances_response = match context
             .ec2_client
             .describe_instances()

--- a/src/integrations/providers/aws/resources/elastic_compute.rs
+++ b/src/integrations/providers/aws/resources/elastic_compute.rs
@@ -119,6 +119,15 @@ impl AwsInterface {
                     .build(),
             );
 
+        if node.allocation_mode.to_lowercase() == "spot" {
+            run_instances_request = run_instances_request
+                .instance_market_options(
+                    aws_sdk_ec2::types::InstanceMarketOptionsRequest::builder()
+                        .market_type(aws_sdk_ec2::types::MarketType::Spot)
+                        .build()
+                );
+        }
+
         if let Some(burstable_mode) = &node.burstable_mode {
             let credit_spec = aws_sdk_ec2::types::CreditSpecificationRequest::builder()
                 .cpu_credits(burstable_mode.to_lowercase())

--- a/src/integrations/providers/aws/resources/elastic_file_system_device.rs
+++ b/src/integrations/providers/aws/resources/elastic_file_system_device.rs
@@ -91,6 +91,7 @@ impl AwsInterface {
             "Disabling automatic backups for EFS device (id='{}')...",
             new_efs_device_id
         );
+        sleep(Duration::from_secs(10)).await;
         match context
             .efs_client
             .put_backup_policy()

--- a/src/integrations/providers/aws/resources/iam_role_and_trust_policy.rs
+++ b/src/integrations/providers/aws/resources/iam_role_and_trust_policy.rs
@@ -183,7 +183,7 @@ impl AwsInterface {
         {
             Ok(response) => {
                 info!(
-                    "Detached SSM trust policy from IAM Role (name='{}')",
+                    "Detached SSM Trust Policy from IAM Role (name='{}')",
                     role_name
                 );
                 response
@@ -210,7 +210,7 @@ impl AwsInterface {
             }
             Err(e) => {
                 error!("{:?}", e);
-                bail!("Failed to delete IAM role (name='{}')", role_name);
+                bail!("Failed to delete IAM Role (name='{}')", role_name);
             }
         };
 


### PR DESCRIPTION
Implementation of spot instantiation.

Basic handling on failure to instantiate instances:
- if any instance fails to launch, terminate the whole cluster, clean up all resources, and return the error.


Terminal on failure to instantiate instances:
![clusters](https://github.com/user-attachments/assets/bc145a2b-0419-4f97-ac42-d0fcc852dbcc)
