### PR TITLE
Creation of user-specified policy in instance creation failure

### DIFF
--- a/cluster.example.yaml
+++ b/cluster.example.yaml
@@ -3,25 +3,34 @@ public_ssh_key_path: ~/.ssh/id_ed25519.pub
 private_ssh_key_path: ~/.ssh/id_ed25519
 provider_id: aws
 region: us-east-1
-availability_zone: us-east-1c
+availability_zone: us-east-1f
 use_node_affinity: false
 use_elastic_fabric_adapters: false
 use_elastic_file_system: true
+on_instance_creation_failure: migrate # or "cancel"
 nodes:
-  - instance_type: t3.2xlarge
-    allocation_mode: on-demand
-    burstable_mode: Standard
-    image_id: ami-0845a3d4093ba6e49
-
-  - instance_type: t3.2xlarge
+  - instance_type: p3.16xlarge
     allocation_mode: spot
-    burstable_mode: Unlimited
     image_id: ami-0845a3d4093ba6e49
     init_commands:
       - ls
 
   - instance_type: m5.2xlarge
     allocation_mode: spot
+    image_id: ami-0845a3d4093ba6e49
+    init_commands:
+      - ls
+
+  - instance_type: t3.2xlarge
+    allocation_mode: on-demand
+    burstable_mode: Standard
+    image_id: ami-0845a3d4093ba6e49
+    init_commands:
+      - ls
+
+  - instance_type: p3.16xlarge
+    allocation_mode: on-demand
+    burstable_mode: Unlimited
     image_id: ami-0845a3d4093ba6e49
     init_commands:
       - ls

--- a/cluster.example.yaml
+++ b/cluster.example.yaml
@@ -7,7 +7,7 @@ availability_zone: us-east-1f
 use_node_affinity: false
 use_elastic_fabric_adapters: false
 use_elastic_file_system: true
-on_instance_creation_failure: migrate # or "cancel"
+on_instance_creation_failure: cancel # or "cancel"
 nodes:
   - instance_type: p3.16xlarge
     allocation_mode: spot
@@ -28,7 +28,7 @@ nodes:
     init_commands:
       - ls
 
-  - instance_type: p3.16xlarge
+  - instance_type: t3.2xlarge 
     allocation_mode: on-demand
     burstable_mode: Unlimited
     image_id: ami-0845a3d4093ba6e49

--- a/cluster.example.yaml
+++ b/cluster.example.yaml
@@ -7,7 +7,7 @@ availability_zone: us-east-1f
 use_node_affinity: false
 use_elastic_fabric_adapters: false
 use_elastic_file_system: true
-on_instance_creation_failure: cancel # or "cancel"
+on_instance_creation_failure: migrate # or "cancel"
 nodes:
   - instance_type: p3.16xlarge
     allocation_mode: spot

--- a/migrations/4__add_cluster_and_node_tables.sql
+++ b/migrations/4__add_cluster_and_node_tables.sql
@@ -15,6 +15,7 @@ CREATE TABLE clusters (
     state TEXT NOT NULL,
     on_instance_creation_failure TEXT,
     migration_attempts INTEGER,
+    tried_zones TEXT,
     FOREIGN KEY (provider_config_id) REFERENCES provider_configs(id),
     FOREIGN KEY (provider_id) REFERENCES providers(id)
 );

--- a/migrations/4__add_cluster_and_node_tables.sql
+++ b/migrations/4__add_cluster_and_node_tables.sql
@@ -14,6 +14,7 @@ CREATE TABLE clusters (
     created_at DATETIME NOT NULL,
     state TEXT NOT NULL,
     on_instance_creation_failure TEXT,
+    migration_attempts INTEGER,
     FOREIGN KEY (provider_config_id) REFERENCES provider_configs(id),
     FOREIGN KEY (provider_id) REFERENCES providers(id)
 );

--- a/migrations/4__add_cluster_and_node_tables.sql
+++ b/migrations/4__add_cluster_and_node_tables.sql
@@ -13,6 +13,7 @@ CREATE TABLE clusters (
     use_elastic_file_system BOOLEAN NOT NULL,
     created_at DATETIME NOT NULL,
     state TEXT NOT NULL,
+    on_instance_creation_failure TEXT,
     FOREIGN KEY (provider_config_id) REFERENCES provider_configs(id),
     FOREIGN KEY (provider_id) REFERENCES providers(id)
 );

--- a/src/commands/cluster/create.rs
+++ b/src/commands/cluster/create.rs
@@ -1,5 +1,5 @@
 use crate::database::models::{
-    Cluster, ClusterState, InstanceType, Node, Provider, ProviderConfig, ShellCommand,
+    Cluster, ClusterState, InstanceType, Node, Provider, ProviderConfig, ShellCommand, InstanceCreationFailurePolicy
 };
 use crate::integrations::{cloud_interface::CloudInfoProvider, providers::aws::AwsInterface};
 use crate::utils;
@@ -454,6 +454,7 @@ pub async fn create(
         use_elastic_file_system: cluster_yaml.use_elastic_file_system,
         created_at: Utc::now().naive_utc(),
         state: ClusterState::Pending,
+        on_instance_creation_failure: Some(InstanceCreationFailurePolicy::Cancel), // 'cancel' as default
     };
     cluster
         .insert(pool, nodes_to_insert, commands_to_insert)

--- a/src/commands/cluster/spawn.rs
+++ b/src/commands/cluster/spawn.rs
@@ -5,6 +5,7 @@ use crate::utils;
 use anyhow::{Result, bail};
 use sqlx::sqlite::SqlitePool;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub async fn spawn(pool: &SqlitePool, cluster_id: &str, skip_confirmation: bool) -> Result<()> {
     let cluster = match Cluster::fetch_by_id(pool, cluster_id).await? {
@@ -28,7 +29,7 @@ pub async fn spawn(pool: &SqlitePool, cluster_id: &str, skip_confirmation: bool)
     let config_vars = provider_config.get_config_vars(pool).await?;
     let provider_id = provider_config.provider_id.clone();
     let cloud_interface = match provider_id.as_str() {
-        "aws" => AwsInterface { config_vars },
+        "aws" => AwsInterface { config_vars, db_pool: Arc::new(pool.clone()) },
         _ => {
             bail!(
                 "Provider (id='{}') is currently not supported.",

--- a/src/commands/cluster/terminate.rs
+++ b/src/commands/cluster/terminate.rs
@@ -5,6 +5,7 @@ use crate::utils;
 use anyhow::{Result, bail};
 use sqlx::sqlite::SqlitePool;
 use tracing::{error, info};
+use std::sync::Arc;
 
 pub async fn terminate(pool: &SqlitePool, cluster_id: &str, skip_confirmation: bool) -> Result<()> {
     let cluster = match Cluster::fetch_by_id(pool, cluster_id).await? {
@@ -38,7 +39,7 @@ pub async fn terminate(pool: &SqlitePool, cluster_id: &str, skip_confirmation: b
     let config_vars = provider_config.get_config_vars(pool).await?;
     let provider_id = provider_config.provider_id.clone();
     let cloud_interface = match provider_id.as_str() {
-        "aws" => AwsInterface { config_vars },
+        "aws" => AwsInterface { config_vars, db_pool: Arc::new(pool.clone()) },
         _ => {
             bail!("Provider '{}' is currently not supported.", &provider_id)
         }

--- a/src/commands/instance_type/load.rs
+++ b/src/commands/instance_type/load.rs
@@ -8,6 +8,7 @@ use crate::utils;
 use inquire::Select;
 use sqlx::sqlite::SqlitePool;
 use tracing::error;
+use std::sync::Arc;
 
 pub async fn load(
     pool: &SqlitePool,
@@ -112,7 +113,7 @@ pub async fn load(
     let config_vars = provider_config.get_config_vars(pool).await?;
     let provider_id = provider_config.provider_id.clone();
     let cloud_interface = match provider_id.as_str() {
-        "aws" => CloudProvider::Aws(AwsInterface { config_vars }),
+        "aws" => CloudProvider::Aws(AwsInterface { config_vars, db_pool: Arc::new(pool.clone()) }),
         "vultr" => CloudProvider::Vultr(VultrInterface { config_vars }),
         _ => {
             anyhow::bail!("Provider '{}' is currently not supported.", &provider_id)

--- a/src/database/models/cluster.rs
+++ b/src/database/models/cluster.rs
@@ -1,4 +1,5 @@
-use crate::database::models::{InstanceType, Node, ProviderConfig, ShellCommand};
+use crate::database::models::{InstanceType, Node, ProviderConfig, ShellCommand, InstanceCreationFailurePolicy};
+
 
 use anyhow::{Result, bail};
 use chrono::NaiveDateTime;
@@ -70,6 +71,7 @@ pub struct Cluster {
     pub use_elastic_file_system: bool,
     pub created_at: NaiveDateTime,
     pub state: ClusterState,
+    pub on_instance_creation_failure: Option<InstanceCreationFailurePolicy>,
 }
 
 impl Cluster {
@@ -177,7 +179,8 @@ impl Cluster {
                     use_elastic_fabric_adapters,
                     use_elastic_file_system,
                     created_at,
-                    state as "state: ClusterState"
+                    state as "state: ClusterState",
+                    on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy"
                 FROM clusters
                 WHERE id = ?
             "#,
@@ -213,7 +216,8 @@ impl Cluster {
                     use_elastic_fabric_adapters,
                     use_elastic_file_system,
                     created_at,
-                    state as "state: ClusterState"
+                    state as "state: ClusterState",
+                    on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy"
                 FROM clusters
             "#,
         )

--- a/src/database/models/cluster.rs
+++ b/src/database/models/cluster.rs
@@ -72,6 +72,7 @@ pub struct Cluster {
     pub created_at: NaiveDateTime,
     pub state: ClusterState,
     pub on_instance_creation_failure: Option<InstanceCreationFailurePolicy>,
+    pub migration_attempts: i64,
 }
 
 impl Cluster {
@@ -180,7 +181,8 @@ impl Cluster {
                     use_elastic_file_system,
                     created_at,
                     state as "state: ClusterState",
-                    on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy"
+                    on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy",
+                    migration_attempts as "migration_attempts!"
                 FROM clusters
                 WHERE id = ?
             "#,
@@ -217,7 +219,8 @@ impl Cluster {
                     use_elastic_file_system,
                     created_at,
                     state as "state: ClusterState",
-                    on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy"
+                    on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy",
+                    migration_attempts "migration_attempts!"
                 FROM clusters
             "#,
         )

--- a/src/database/models/cluster.rs
+++ b/src/database/models/cluster.rs
@@ -73,6 +73,7 @@ pub struct Cluster {
     pub state: ClusterState,
     pub on_instance_creation_failure: Option<InstanceCreationFailurePolicy>,
     pub migration_attempts: i64,
+    pub tried_zones: Option<String>,
 }
 
 impl Cluster {
@@ -100,6 +101,10 @@ impl Cluster {
         println!(
             "{:<35}: {}",
             "Use Elastic File System (EFS)", self.use_elastic_file_system
+        );
+        println!(
+            "{:<35}: {}",
+            "On Instance Creation Failure", self.on_instance_creation_failure.clone().unwrap_or(InstanceCreationFailurePolicy::Cancel).to_string()
         );
         println!(
             "{:<35}: {}",
@@ -182,7 +187,8 @@ impl Cluster {
                     created_at,
                     state as "state: ClusterState",
                     on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy",
-                    migration_attempts as "migration_attempts!"
+                    migration_attempts as "migration_attempts!",
+                    tried_zones 
                 FROM clusters
                 WHERE id = ?
             "#,
@@ -220,7 +226,8 @@ impl Cluster {
                     created_at,
                     state as "state: ClusterState",
                     on_instance_creation_failure as "on_instance_creation_failure: InstanceCreationFailurePolicy",
-                    migration_attempts "migration_attempts!"
+                    migration_attempts as "migration_attempts!",
+                    tried_zones
                 FROM clusters
             "#,
         )
@@ -272,9 +279,10 @@ impl Cluster {
                     use_elastic_fabric_adapters,
                     use_elastic_file_system,
                     created_at,
-                    state
+                    state,
+                    on_instance_creation_failure
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             self.id,
             self.display_name,
@@ -289,6 +297,7 @@ impl Cluster {
             self.use_elastic_file_system,
             self.created_at,
             self.state,
+            self.on_instance_creation_failure,
         )
         .execute(&mut *tx)
         .await

--- a/src/database/models/instance_creation_failure_policy.rs
+++ b/src/database/models/instance_creation_failure_policy.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+use sqlx::Type;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Type)]
+#[sqlx(type_name = "TEXT")]
+#[serde(rename_all = "snake_case")]
+pub enum InstanceCreationFailurePolicy {
+    Cancel,
+    Migrate,
+}
+
+impl fmt::Display for InstanceCreationFailurePolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            InstanceCreationFailurePolicy::Cancel => "cancel",
+            InstanceCreationFailurePolicy::Migrate => "migrate",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl FromStr for InstanceCreationFailurePolicy {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cancel" => Ok(InstanceCreationFailurePolicy::Cancel),
+            "migrate" => Ok(InstanceCreationFailurePolicy::Migrate),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/database/models/mod.rs
+++ b/src/database/models/mod.rs
@@ -5,6 +5,7 @@ pub mod node;
 pub mod provider;
 pub mod provider_config;
 pub mod shell_command;
+pub mod instance_creation_failure_policy;
 
 pub use cluster::*;
 pub use instance_type::*;
@@ -13,3 +14,4 @@ pub use node::*;
 pub use provider::*;
 pub use provider_config::*;
 pub use shell_command::*;
+pub use instance_creation_failure_policy::*;

--- a/src/integrations/providers/aws/interface.rs
+++ b/src/integrations/providers/aws/interface.rs
@@ -256,21 +256,4 @@ impl AwsInterface {
             }
         }
     }
-
-    /// Determine if an error is related to capacity/availability issues
-    pub fn is_capacity_error(&self, error: &anyhow::Error) -> bool {
-        let error_msg = error.to_string().to_lowercase();
-        
-        error_msg.contains("insufficient capacity") || 
-        error_msg.contains("capacity not available") || 
-        error_msg.contains("insufficientinstancecapacity") ||
-        error_msg.contains("no capacity") ||
-        error_msg.contains("insufficient instance capacity") ||
-        error_msg.contains("not enough capacity") ||
-        error_msg.contains("capacity-oversubscribed") ||
-        error_msg.contains("capacity constraint") ||
-        error_msg.contains("not supported in the requested availability zone") ||
-        error_msg.contains("no capacity available for the requested spot instance") ||
-        error_msg.contains("spotinstancecapacity")
-    }
 }

--- a/src/integrations/providers/aws/interface.rs
+++ b/src/integrations/providers/aws/interface.rs
@@ -10,6 +10,9 @@ use aws_sdk_pricing::Client as PricingClient;
 use aws_sdk_servicequotas::Client as ServiceQuotasClient;
 use aws_sdk_ssm::Client as SsmClient;
 use std::collections::HashMap;
+use tracing::error;
+use std::sync::Arc;
+use sqlx::SqlitePool;
 
 /// Context struct containing all cluster-related information and resource identifiers
 /// used throughout the cluster lifecycle operations
@@ -150,6 +153,7 @@ impl AwsClusterContext {
 
 pub struct AwsInterface {
     pub config_vars: Vec<ConfigVar>,
+    pub db_pool: Arc<SqlitePool>,
 }
 
 impl AwsInterface {
@@ -224,5 +228,49 @@ impl AwsInterface {
         Ok(AwsClusterContext::new(
             cluster, ec2_client, efs_client, ssm_client, iam_client,
         ))
+    }
+
+    /// Get all availability zones in the specified region
+    pub async fn get_all_availability_zones(&self, ec2_client: &Ec2Client, region: &str) -> Result<Vec<String>> {
+        match ec2_client.describe_availability_zones().send().await {
+            Ok(resp) => {
+                let zones: Vec<String> = resp
+                    .availability_zones
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|r| r.zone_name)
+                    .collect();
+
+                if zones.is_empty() {
+                    bail!("No availability zones found in region '{}'", region);
+                }
+
+                Ok(zones)
+            }
+            Err(e) => {
+                error!("{:?}", e);
+                bail!(
+                    "Failed to fetch AWS availability zones for region '{}'",
+                    region
+                )
+            }
+        }
+    }
+
+    /// Determine if an error is related to capacity/availability issues
+    pub fn is_capacity_error(&self, error: &anyhow::Error) -> bool {
+        let error_msg = error.to_string().to_lowercase();
+        
+        error_msg.contains("insufficient capacity") || 
+        error_msg.contains("capacity not available") || 
+        error_msg.contains("insufficientinstancecapacity") ||
+        error_msg.contains("no capacity") ||
+        error_msg.contains("insufficient instance capacity") ||
+        error_msg.contains("not enough capacity") ||
+        error_msg.contains("capacity-oversubscribed") ||
+        error_msg.contains("capacity constraint") ||
+        error_msg.contains("not supported in the requested availability zone") ||
+        error_msg.contains("no capacity available for the requested spot instance") ||
+        error_msg.contains("spotinstancecapacity")
     }
 }

--- a/src/integrations/providers/aws/resource_manager.rs
+++ b/src/integrations/providers/aws/resource_manager.rs
@@ -22,8 +22,10 @@ impl CloudResourceManager for AwsInterface {
 
         let attempts: usize = cluster.migration_attempts as usize;
         if attempts >= MAX_MIGRATION_ATTEMPTS {
-            bail!("Maximum migration attempts reached for cluster '{}'.", cluster.display_name);
+            bail!("\nMaximum migration of {} attempts reached for cluster '{}'.", attempts, cluster.display_name);
         }
+
+        eprintln!("\n ATTEMPT: {}", attempts+1);
 
         let mut context = self.create_cluster_context(&cluster)?;
         let mut steps = 8 + (4 * nodes.len()) + nodes.len();
@@ -203,90 +205,86 @@ impl CloudResourceManager for AwsInterface {
                 .await {
                     Ok(id) => id,
                     Err(e) => {
+                        match cluster.on_instance_creation_failure.as_ref().unwrap_or(&InstanceCreationFailurePolicy::Cancel) {
+                            InstanceCreationFailurePolicy::Cancel => {
+                                // Stop the progress bars before printing errors
+                                operation_spinner.finish_with_message("Error occurred, cleaning up...");
+                                main_progress.finish_with_message("Cluster creation failed.");
+                                
+                                // Print the error
+                                eprintln!("Failed to create instance for node {}: {:#}", node_index+1, e);
+                                eprintln!("\nDestroying and canceling the cluster");
 
-                        if self.is_capacity_error(&e) {
-                            match cluster.on_instance_creation_failure.as_ref().unwrap_or(&InstanceCreationFailurePolicy::Cancel) {
-                                InstanceCreationFailurePolicy::Cancel => {
-                                    // Stop the progress bars before printing errors
-                                    operation_spinner.finish_with_message("Error occurred, cleaning up...");
-                                    main_progress.finish_with_message("Cluster creation failed.");
-                                    
-                                    // Print the error
-                                    eprintln!("Failed to create instance for node {} due to capacity issues: {:#}", node_index, e);
-
-                                    // Attempt to terminate/cleanup the cluster
-                                    let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
-                                    if let Err(cleanup_err) = cleanup_result {
-                                        error!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
-                                    }
-                                },
-                                InstanceCreationFailurePolicy::Migrate => {
-                                    // Stop the progress bars before printing errors
-                                    operation_spinner.finish_with_message("Error occurred, cleaning up...");
-                                    main_progress.finish_with_message("Cluster creation failed.");
-                                    
-                                    // Print the error
-                                    eprintln!("Failed to create instance for node {} due to capacity issues: {:#}", node_index, e);
-
-                                    // Attempt to terminate/cleanup the cluster
-                                    let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
-                                    if let Err(cleanup_err) = cleanup_result {
-                                        bail!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
-                                    }
-
-                                    // Get all available zones in the region
-                                    let all_zones = self.get_all_availability_zones(&context.ec2_client, &cluster.region).await?;
-
-                                    // Filter out the current zone that failed
-                                    let alternative_zones: Vec<_> = all_zones.into_iter()
-                                        .filter(|z| z != &cluster.availability_zone)
-                                        .collect();
-                                    if alternative_zones.is_empty() {
-                                        bail!("No alternative availability zones available in region {}", cluster.region);
-                                    }
-
-                                    // Try next alternative zone
-                                    if let Some(zone) = alternative_zones.first() {
-                                        info!("Attempting to create cluster in zone {}", zone);
-
-                                        // Update the cluster with the new zone
-                                        let mut new_cluster = cluster.clone();
-                                        new_cluster.availability_zone = zone.clone();
-                                        new_cluster.migration_attempts += 1;
-
-                                        // Update the database
-                                        sqlx::query! (
-                                            "UPDATE clusters SET availability_zone = $1 WHERE id = $2",
-                                            zone,
-                                            new_cluster.id
-                                        )
-                                        .execute(&*self.db_pool)
-                                        .await?;
-
-                                        // Try creating the cluster in the new zone
-                                        return Box::pin(self.spawn_cluster(
-                                            new_cluster,
-                                            nodes.clone(),
-                                            init_commands.clone(),
-                                        )).await;
-                                    }
-
-                                    // If get here, all zones failed
-                                    bail!("Failed to find an availability zone with sufficient capacity");
+                                // Attempt to terminate/cleanup the cluster
+                                let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
+                                if let Err(cleanup_err) = cleanup_result {
+                                    error!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
                                 }
-                            }
-                        } else {
-                            // Stop the progress bars before printing errors
-                            operation_spinner.finish_with_message("Error occurred, cleaning up...");
-                            main_progress.finish_with_message("Cluster creation failed.");
-                            
-                            // Print the error
-                            eprintln!("Failed to create instance for node {} due to capacity issues: {:#}", node_index, e);
+                            },
+                            InstanceCreationFailurePolicy::Migrate => {
+                                // Stop the progress bars before printing errors
+                                operation_spinner.finish_with_message("Error occurred, cleaning up...");
+                                main_progress.finish_with_message("Cluster creation failed.");
+                                
+                                // Print the error
+                                eprintln!("Failed to create instance for node {} in availability zone {}: {:#}", node_index+1, cluster.availability_zone, e);
+                                eprintln!("\nDestroying cluster and retrying in a different availability zone.");
 
-                            // Attempt to terminate/cleanup the cluster
-                            let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
-                            if let Err(cleanup_err) = cleanup_result {
-                                error!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
+                                // Attempt to terminate/cleanup the cluster
+                                let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
+                                if let Err(cleanup_err) = cleanup_result {
+                                    bail!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
+                                }
+
+                                // Split the tried_zones string into a Vec<&str>, removing empty entries
+                                let mut tried_zones: Vec<_> = cluster.tried_zones
+                                    .as_deref()
+                                    .unwrap_or("")
+                                    .split(',')
+                                    .filter(|s| !s.is_empty())
+                                    .collect();
+                                tried_zones.push(cluster.availability_zone.as_str());
+
+                                // Get all available zones in the region
+                                let all_zones = self.get_all_availability_zones(&context.ec2_client, &cluster.region).await?;
+
+                                // Filter out the current zone that failed
+                                let alternative_zones: Vec<_> = all_zones.into_iter()
+                                    .filter(|z| !tried_zones.contains(&z.as_str()))
+                                    .collect();
+                                if alternative_zones.is_empty() {
+                                    bail!("No alternative availability zones available in region {}", cluster.region);
+                                }
+
+                                // Try next alternative zone
+                                if let Some(zone) = alternative_zones.first() {
+                                    eprintln!("Attempting to create cluster in zone {}", zone);
+
+                                    // Update the cluster with the new zone
+                                    let mut new_cluster = cluster.clone();
+                                    new_cluster.tried_zones = Some(tried_zones.join(","));
+                                    new_cluster.availability_zone = zone.clone();
+                                    new_cluster.migration_attempts += 1;
+
+                                    // Update the database
+                                    sqlx::query! (
+                                        "UPDATE clusters SET availability_zone = $1 WHERE id = $2",
+                                        zone,
+                                        new_cluster.id
+                                    )
+                                    .execute(&*self.db_pool)
+                                    .await?;
+
+                                    // Try creating the cluster in the new zone
+                                    return Box::pin(self.spawn_cluster(
+                                        new_cluster,
+                                        nodes.clone(),
+                                        init_commands.clone(),
+                                    )).await;
+                                }
+
+                                // If get here, all zones failed
+                                bail!("Failed to find an availability zone with sufficient capacity");
                             }
                         }
                         return Err(e);

--- a/src/integrations/providers/aws/resource_manager.rs
+++ b/src/integrations/providers/aws/resource_manager.rs
@@ -1,5 +1,5 @@
 use super::interface::AwsInterface;
-use crate::database::models::{Cluster, Node};
+use crate::database::models::{Cluster, Node, InstanceCreationFailurePolicy};
 use crate::integrations::CloudResourceManager;
 use crate::utils;
 
@@ -8,6 +8,9 @@ use std::collections::HashMap;
 use anyhow::Result;
 use tracing::info;
 use tracing::error;
+use anyhow::bail;
+
+const MAX_MIGRATION_ATTEMPTS: usize = 3;
 
 impl CloudResourceManager for AwsInterface {
     async fn spawn_cluster(
@@ -16,6 +19,12 @@ impl CloudResourceManager for AwsInterface {
         nodes: Vec<Node>,
         init_commands: HashMap<usize, Vec<String>>,
     ) -> Result<()> {
+
+        let attempts: usize = cluster.migration_attempts as usize;
+        if attempts >= MAX_MIGRATION_ATTEMPTS {
+            bail!("Maximum migration attempts reached for cluster '{}'.", cluster.display_name);
+        }
+
         let mut context = self.create_cluster_context(&cluster)?;
         let mut steps = 8 + (4 * nodes.len()) + nodes.len();
         if cluster.use_node_affinity {
@@ -181,7 +190,6 @@ impl CloudResourceManager for AwsInterface {
         }
 
         // 14. Request EC2 Instances
-        // Current approach: if any instance fails to launch, terminate the whole cluster, clean up all resources, and return the error
         for (node_index, node) in nodes.iter().enumerate() {
             // 14.1. Request EC2 instance creation...
             operation_spinner.update_message(&format!(
@@ -195,19 +203,92 @@ impl CloudResourceManager for AwsInterface {
                 .await {
                     Ok(id) => id,
                     Err(e) => {
-                        // Stop the progress bars before printing errors
-                        operation_spinner.finish_with_message("Error occurred, cleaning up...");
-                        main_progress.finish_with_message("Cluster creation failed.");
-                        
-                        // Print the error
-                        eprintln!("Failed to create instance for node {}: {:#}", node_index, e);
 
-                        // Attempt to terminate/cleanup the cluster
-                        let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
-                        if let Err(cleanup_err) = cleanup_result {
-                            error!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
+                        if self.is_capacity_error(&e) {
+                            match cluster.on_instance_creation_failure.as_ref().unwrap_or(&InstanceCreationFailurePolicy::Cancel) {
+                                InstanceCreationFailurePolicy::Cancel => {
+                                    // Stop the progress bars before printing errors
+                                    operation_spinner.finish_with_message("Error occurred, cleaning up...");
+                                    main_progress.finish_with_message("Cluster creation failed.");
+                                    
+                                    // Print the error
+                                    eprintln!("Failed to create instance for node {} due to capacity issues: {:#}", node_index, e);
+
+                                    // Attempt to terminate/cleanup the cluster
+                                    let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
+                                    if let Err(cleanup_err) = cleanup_result {
+                                        error!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
+                                    }
+                                },
+                                InstanceCreationFailurePolicy::Migrate => {
+                                    // Stop the progress bars before printing errors
+                                    operation_spinner.finish_with_message("Error occurred, cleaning up...");
+                                    main_progress.finish_with_message("Cluster creation failed.");
+                                    
+                                    // Print the error
+                                    eprintln!("Failed to create instance for node {} due to capacity issues: {:#}", node_index, e);
+
+                                    // Attempt to terminate/cleanup the cluster
+                                    let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
+                                    if let Err(cleanup_err) = cleanup_result {
+                                        bail!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
+                                    }
+
+                                    // Get all available zones in the region
+                                    let all_zones = self.get_all_availability_zones(&context.ec2_client, &cluster.region).await?;
+
+                                    // Filter out the current zone that failed
+                                    let alternative_zones: Vec<_> = all_zones.into_iter()
+                                        .filter(|z| z != &cluster.availability_zone)
+                                        .collect();
+                                    if alternative_zones.is_empty() {
+                                        bail!("No alternative availability zones available in region {}", cluster.region);
+                                    }
+
+                                    // Try next alternative zone
+                                    if let Some(zone) = alternative_zones.first() {
+                                        info!("Attempting to create cluster in zone {}", zone);
+
+                                        // Update the cluster with the new zone
+                                        let mut new_cluster = cluster.clone();
+                                        new_cluster.availability_zone = zone.clone();
+                                        new_cluster.migration_attempts += 1;
+
+                                        // Update the database
+                                        sqlx::query! (
+                                            "UPDATE clusters SET availability_zone = $1 WHERE id = $2",
+                                            zone,
+                                            new_cluster.id
+                                        )
+                                        .execute(&*self.db_pool)
+                                        .await?;
+
+                                        // Try creating the cluster in the new zone
+                                        return Box::pin(self.spawn_cluster(
+                                            new_cluster,
+                                            nodes.clone(),
+                                            init_commands.clone(),
+                                        )).await;
+                                    }
+
+                                    // If get here, all zones failed
+                                    bail!("Failed to find an availability zone with sufficient capacity");
+                                }
+                            }
+                        } else {
+                            // Stop the progress bars before printing errors
+                            operation_spinner.finish_with_message("Error occurred, cleaning up...");
+                            main_progress.finish_with_message("Cluster creation failed.");
+                            
+                            // Print the error
+                            eprintln!("Failed to create instance for node {} due to capacity issues: {:#}", node_index, e);
+
+                            // Attempt to terminate/cleanup the cluster
+                            let cleanup_result = self.destroy_cluster(cluster.clone(), nodes.clone()).await;
+                            if let Err(cleanup_err) = cleanup_result {
+                                error!("Failed to cleanup cluster after instance creation failure: {:?}", cleanup_err);
+                            }
                         }
-
                         return Err(e);
                     }
                 };


### PR DESCRIPTION
Implementation of two policies in instances creation failure:

- Cancel:
  - If any instance fails to launch, terminate the whole cluster, clean up all resources, and return the error.
  
   - Terminal on failure to instantiate instances with cancel policy:
   - ![image](https://github.com/user-attachments/assets/2ac2c238-28cb-469a-9a32-59f52aa1647b)

- Migrate:
  - If any instance fails to launch, terminate the whole cluster, cleaning up all resources, and try call again the spawn function with a new cluster configuration with the next availability-zone.
  - The application tries to migrate for MAX_MIGRATION_ATTEMPTS, if all the attempts fail, it just returns the error.
  
   - Terminal on failure to instantiate instances with migrate policy:
   - ![image](https://github.com/user-attachments/assets/db1f138c-7dde-4195-b545-168b5f1e8e81)